### PR TITLE
Fix animation repeat value type from Int to String

### DIFF
--- a/src/AFrame.elm
+++ b/src/AFrame.elm
@@ -1,6 +1,6 @@
 module AFrame exposing (..)
 
-{-| [A-Frame](https://aframe.io/docs/0.2.0/guide/) is a open-source framework for creating 3D and virtual reality experiences on the web.
+{-| [A-Frame](https://aframe.io/docs/0.2.0/guide/) is an open-source framework for creating 3D and virtual reality experiences on the web.
 
 # Scene
 @docs scene

--- a/src/AFrame/Animations.elm
+++ b/src/AFrame/Animations.elm
@@ -112,11 +112,11 @@ from value =
 
 {-| Repeat count or indefinite.
 
-    animation [ repeat 5000 ] []
+    animation [ repeat "5000" ] []
 -}
-repeat : Int -> Attribute msg
+repeat : String -> Attribute msg
 repeat value =
-    attribute "repeat" (toString value)
+    attribute "repeat" value
 
 
 {-| Ending value. Must be specified.

--- a/src/AFrame/Extra/Physics.elm
+++ b/src/AFrame/Extra/Physics.elm
@@ -32,9 +32,9 @@ grid =
     node "a-grid"
 
 
-{-| A freely-moving object. Dynamic bodies have mass,
-    collide with other objects, bounce or slow during collisions,
-    and fall if gravity is enabled.
+{-| A freely-moving object.
+    Dynamic bodies have mass, collide with other objects,
+    bounce or slow during collisions, and fall if gravity is enabled.
 
     box [ dynamicBody ] []
 -}
@@ -55,11 +55,11 @@ staticBody =
 
 
 {-| Player-controlled body, which can move but is not affected (directly)
-    y the physics engine. Intended for use on the player's model.
+    by the physics engine. Intended for use on the player's model.
     Gravity and collisions are simulated,
     without giving full control to the physics engine.
 
-    box [ staticBody ] []
+    box [ kinematicBody ] []
 -}
 kinematicBody : Attribute msg
 kinematicBody =

--- a/src/AFrame/Primitives/Camera.elm
+++ b/src/AFrame/Primitives/Camera.elm
@@ -1,6 +1,6 @@
 module AFrame.Primitives.Camera exposing (..)
 
-{-| CAmera primitive.
+{-| Camera primitive.
 
 # Primitives
 @docs camera


### PR DESCRIPTION
1. Corrected some typos.
2. Animation `repeat` attribute's `value` is expected to be `Int` and because of that it's not possible to set `"indefinite"` value. The argument type should be `String`.

As a workaround I have used:
```elm
attribute "repeat" "indefinite"
``` 