### PR TITLE
Add raycaster attribute to cursor and text primitive

### DIFF
--- a/src/AFrame/Primitives.elm
+++ b/src/AFrame/Primitives.elm
@@ -3,7 +3,7 @@ module AFrame.Primitives exposing (..)
 {-| A-Frame primitives.
 
 # Geometric primitives
-@docs box, cone, cylinder, plane, sphere, ring, torus, image
+@docs box, cone, cylinder, plane, sphere, ring, torus, image, text
 
 # Scene primitives
 @docs sky, light
@@ -107,3 +107,10 @@ assetItem =
 image : List (Attribute msg) -> List (Html msg) -> Html msg
 image =
     node "a-image"
+
+
+{-| The text primitive displays a text.
+-}
+text : List (Attribute msg) -> List (Html msg) -> Html msg
+text =
+    node "a-text"

--- a/src/AFrame/Primitives/Cursor.elm
+++ b/src/AFrame/Primitives/Cursor.elm
@@ -6,7 +6,7 @@ module AFrame.Primitives.Cursor exposing (..)
 @docs cursor
 
 # Attributes
-@docs fuse, maxDistance, timeout
+@docs fuse, maxDistance, timeout, raycaster
 
 -}
 
@@ -42,3 +42,10 @@ maxDistance value =
 timeout : Int -> Attribute msg
 timeout value =
     attribute "timeout" (toString value)
+
+
+{-| Customize the raycasting pieces of the cursor.
+-}
+raycaster : String -> Attribute msg
+raycaster value =
+    attribute "raycaster" (toString value)


### PR DESCRIPTION
1. Would be great to be able to use `raycaster` attribute.

Ref: https://aframe.io/docs/0.5.0/components/cursor.html#configuring-the-cursor-through-the-raycaster-component

2. Added missing [text](https://aframe.io/docs/0.5.0/primitives/a-text.html) primitive.

_Please ignore the previous PR (already closed) as I have messed something up with the commits._